### PR TITLE
fix: use Selector.ToString() == propertyExpression.ToString() instead…

### DIFF
--- a/SuperFilter/Extensions.cs
+++ b/SuperFilter/Extensions.cs
@@ -17,7 +17,7 @@ internal static class SuperfilterExtensions
         string propertyName = ((MemberExpression)body).Member.Name;
 
         KeyValuePair<string, FieldConfiguration> kvp = globalConfiguration.PropertyMappings
-            .FirstOrDefault(x => x.Value.GetPropertyName().Equals(propertyName, StringComparison.InvariantCultureIgnoreCase));
+            .FirstOrDefault(x => x.Value.Selector.ToString() == propertyExpression.ToString());
 
         if (kvp.Key == null || kvp.Value == null)
             return query;
@@ -25,17 +25,13 @@ internal static class SuperfilterExtensions
         string actualKey = kvp.Key;
         FieldConfiguration fieldConfig = kvp.Value;
 
-
-        string filterFieldName = propertyName;
-        
-
         FilterCriterion? filter = globalConfiguration.HasFilters.Filters
             .FirstOrDefault(filters => string.Equals(filters.Field, actualKey, StringComparison.CurrentCultureIgnoreCase));
 
         if (filter == null || string.IsNullOrEmpty(filter.Value))
         {
             if (fieldConfig.IsRequired)
-                throw new SuperfilterException($"Filter {filterFieldName} is required.");
+                throw new SuperfilterException($"Filter {propertyName} is required.");
             return query;
         }
 

--- a/SuperFilter/SuperFilter.ExpressionUtils.cs
+++ b/SuperFilter/SuperFilter.ExpressionUtils.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -20,7 +19,6 @@ public partial class Superfilter
     private static Type ExtractPropertyTypeFromSelector(LambdaExpression selector)
     {
         Expression body = selector.Body is UnaryExpression unary ? unary.Operand : selector.Body;
-
         if (body is MemberExpression memberExpression) return ((PropertyInfo)memberExpression.Member).PropertyType;
 
         throw new SuperfilterException("Unable to determine property type from selector.");


### PR DESCRIPTION
… propertyName comparison  which can provide many conflict