### PR TITLE
Switch license to MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,26 +1,21 @@
-# Superfilter Public License v1.0 (based on the MIT License)
+MIT License
 
-**Copyright (c) 2025 Ibrahim Madi**
+Copyright (c) 2025 Ibrahim Madi
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to use, copy, modify, merge, publish, and distribute the Software, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-## Attribution
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software. Proper credit must be given to the original author, Ibrahim Madi.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-## Non-commercial freedom
-The Software may be freely used and modified for personal, educational, research, or internal purposes, including within companies, provided it is not sold or turned into a standalone commercial product.
-
-## Commercial restriction
-It is not permitted, without explicit written permission from the copyright holder:
-
-- to sell the Software or any modified version of it,
-- to create or distribute a commercial product or service based substantially on this Software,
-- to distribute modified versions as standalone commercial offerings.
-
-## Use as a dependency
-The Software may be used as a dependency or component in commercial or open-source projects, as long as:
-- it is not the main functionality of the product.
-
----
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -120,13 +120,4 @@ dotnet test
 
 ## License
 
-This project is licensed under the SuperFilter Public License v1.0, based on the MIT License. 
-
-**Key Points:**
-- ✅ **Free to use** as a dependency in your commercial or open-source projects
-- ✅ **Free for personal, educational, and research purposes**
-- ✅ **Attribution required**
-- ❌ **Cannot create a commercial product derived/forked from the codebase of Superfilter** without explicit permission
-- ❌ **Cannot sell or redistribute** as a standalone commercial offering
-
-See the [LICENSE](LICENSE) file for full details.
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary
- replace custom Superfilter license text with standard MIT license
- update README license section

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68754452c988832ab995292205941c5d